### PR TITLE
Add automaton based implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,9 +187,17 @@ name = "roget"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "fst",
  "itertools",
  "once_cell",
+ "wordle-automaton",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "strsim"
@@ -259,3 +273,13 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wordle-automaton"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925f746496b03ba1d611b2b4085df8866d1712b759dcd18b1d647edf1194b586"
+dependencies = [
+ "fst",
+ "smallvec",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ debug = true
 itertools = "0.10"
 clap = { version = "3", features = ["derive"] }
 once_cell = "1"
+wordle-automaton = "^0.9.0"
+fst = "0.4.7"

--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -14,3 +14,5 @@ mod prune;
 pub use prune::Prune;
 mod cutoff;
 pub use cutoff::Cutoff;
+mod automaton;
+pub use automaton::Automaton;

--- a/src/algorithms/automaton.rs
+++ b/src/algorithms/automaton.rs
@@ -1,0 +1,71 @@
+use crate::{Correctness, Guess, Guesser, DICTIONARY};
+use fst::{IntoStreamer, Map, Streamer};
+use once_cell::sync::OnceCell;
+use wordle_automaton::{prepare, Wordle, WordleBuilder};
+
+type Fst = Map<Vec<u8>>;
+
+fn prepare_dict() -> &'static Fst {
+    static FST: OnceCell<Fst> = OnceCell::new();
+
+    FST.get_or_init(|| {
+        let words = DICTIONARY
+            .lines()
+            .filter_map(|line| Some(line.split_once(' ')?.0))
+            .collect::<Vec<_>>();
+        let words = prepare::score_word_list::<_, 5>(words);
+        prepare::build_fst(words).expect("Dictionary is utf-8 sorted")
+    })
+}
+
+pub struct Automaton {
+    fst: &'static Fst,
+    wordle: Wordle<5>,
+    best: [u8; 5],
+}
+
+impl Automaton {
+    pub fn new() -> Self {
+        Self {
+            fst: prepare_dict(),
+            wordle: WordleBuilder::<5>::new().build(),
+            best: [b'z'; 5],
+        }
+    }
+}
+
+impl Guesser for Automaton {
+    fn guess(&mut self, history: &[Guess]) -> String {
+        let guess = match history.last() {
+            None => "tares",
+            Some(last) => {
+                let wordle = std::mem::replace(&mut self.wordle, Wordle::new());
+                let mut wb = WordleBuilder::from(wordle);
+
+                let word = last.word.as_bytes();
+                for (pos, (correctness, b)) in last.mask.iter().zip(word).enumerate() {
+                    match correctness {
+                        Correctness::Correct => wb.correct_pos(pos, *b),
+                        Correctness::Misplaced => wb.wrong_pos(pos, *b),
+                        Correctness::Wrong => wb.never(*b),
+                    };
+                }
+                self.wordle = wb.build();
+
+                let mut solutions = self.fst.search(&self.wordle).into_stream();
+                let mut best_score = 0;
+
+                while let Some((word, score)) = solutions.next() {
+                    if score > best_score {
+                        best_score = score;
+                        self.best.copy_from_slice(word);
+                    }
+                }
+
+                std::str::from_utf8(&self.best).unwrap()
+            }
+        };
+
+        guess.to_string()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ enum Implementation {
     Weight,
     Prune,
     Cutoff,
+    Automaton,
 }
 
 fn main() {
@@ -53,6 +54,9 @@ fn main() {
         }
         Implementation::Cutoff => {
             play(roget::algorithms::Cutoff::new, args.max);
+        }
+        Implementation::Automaton => {
+            play(roget::algorithms::Automaton::new, args.max);
         }
     }
 }


### PR DESCRIPTION
I had a [solver implemented](http://gh.knutwalker.io/wordle-solvers) that is representing the known constraints
as an automaton and uses that one to search in an FST based on
a provided wordlist.

A comparison on my machine looks interesting

```
❯ hyperfine -w 1 -L implementation prune,cutoff,automaton -n '{implementation}' './target/release/roget --implementation {implementation}'
Benchmark 1: prune
  Time (mean ± σ):     17.646 s ±  0.055 s    [User: 17.525 s, System: 0.098 s]
  Range (min … max):   17.597 s … 17.785 s    10 runs

Benchmark 2: cutoff
  Time (mean ± σ):      8.708 s ±  0.005 s    [User: 8.653 s, System: 0.051 s]
  Range (min … max):    8.701 s …  8.718 s    10 runs

Benchmark 3: automaton
  Time (mean ± σ):     685.0 ms ±   1.1 ms    [User: 679.1 ms, System: 4.8 ms]
  Range (min … max):   683.3 ms … 686.7 ms    10 runs

Summary
  'automaton' ran
   12.71 ± 0.02 times faster than 'cutoff'
   25.76 ± 0.09 times faster than 'prune'
```

This implementation also uses a fixed first word, though that one can
also be calculated by using an empty automaton in the first iteration.

Note, this is completely different approach and I wasn't looking into any theory when I was originally implementing this. I'm not really looking into getting this merged, just wanted to see if I can run my solver through this framework and see how it performs.