### PR TITLE
Use separate method for checking correctness of a pattern

### DIFF
--- a/src/algorithms/cutoff.rs
+++ b/src/algorithms/cutoff.rs
@@ -71,11 +71,11 @@ impl Guesser for Cutoff {
                 // considering a world where we _did_ guess `word` and got `pattern` as the
                 // correctness. now, compute what _then_ is left.
                 let mut in_pattern_total = 0;
+                let g = Guess {
+                    word: Cow::Borrowed(word),
+                    mask: *pattern,
+                };
                 for (candidate, count) in &*self.remaining {
-                    let g = Guess {
-                        word: Cow::Borrowed(word),
-                        mask: *pattern,
-                    };
                     if g.matches(candidate) {
                         in_pattern_total += count;
                     }

--- a/src/algorithms/cutoff.rs
+++ b/src/algorithms/cutoff.rs
@@ -72,7 +72,11 @@ impl Guesser for Cutoff {
                 // correctness. now, compute what _then_ is left.
                 let mut in_pattern_total = 0;
                 for (candidate, count) in &*self.remaining {
-                    if Correctness::check(candidate, word, pattern) {
+                    let g = Guess {
+                        word: Cow::Borrowed(word),
+                        mask: *pattern,
+                    };
+                    if g.matches(candidate) {
                         in_pattern_total += count;
                     }
                 }

--- a/src/algorithms/cutoff.rs
+++ b/src/algorithms/cutoff.rs
@@ -72,11 +72,7 @@ impl Guesser for Cutoff {
                 // correctness. now, compute what _then_ is left.
                 let mut in_pattern_total = 0;
                 for (candidate, count) in &*self.remaining {
-                    let g = Guess {
-                        word: Cow::Borrowed(word),
-                        mask: *pattern,
-                    };
-                    if g.matches(candidate) {
+                    if Correctness::check(candidate, word, pattern) {
                         in_pattern_total += count;
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,44 @@ pub enum Correctness {
 }
 
 impl Correctness {
+    fn check(answer: &str, guess: &str, expected: &[Self; 5]) -> bool {
+        assert_eq!(answer.len(), 5);
+        assert_eq!(guess.len(), 5);
+        let mut used = [false; 5];
+
+        // Check Correct letters
+        for (i, (a, g)) in answer.bytes().zip(guess.bytes()).enumerate() {
+            if a == g {
+                if expected[i] != Correctness::Correct {
+                    return false;
+                }
+                used[i] = true;
+            } else if expected[i] == Correctness::Correct {
+                return false;
+            }
+        }
+
+        // Check Misplaced letters
+        for (g, e) in guess.bytes().zip(expected.iter()) {
+            if *e == Correctness::Correct {
+                continue;
+            }
+            let is_misplaced = answer.bytes().enumerate().any(|(i, a)| {
+                if a == g && !used[i] {
+                    used[i] = true;
+                    return true;
+                }
+                false
+            });
+            if is_misplaced != (*e == Correctness::Misplaced) {
+                return false;
+            }
+        }
+
+        // The rest will be all correctly Wrong letters
+        true
+    }
+
     fn compute(answer: &str, guess: &str) -> [Self; 5] {
         assert_eq!(answer.len(), 5);
         assert_eq!(guess.len(), 5);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,16 @@ pub enum Correctness {
 }
 
 impl Correctness {
+    fn is_misplaced(letter: u8, answer: &str, used: &mut [bool; 5]) -> bool {
+        answer.bytes().enumerate().any(|(i, a)| {
+            if a == letter && !used[i] {
+                used[i] = true;
+                return true;
+            }
+            false
+        })
+    }
+
     fn check(answer: &str, guess: &str, expected: &[Self; 5]) -> bool {
         assert_eq!(answer.len(), 5);
         assert_eq!(guess.len(), 5);
@@ -76,14 +86,7 @@ impl Correctness {
             if *e == Correctness::Correct {
                 continue;
             }
-            let is_misplaced = answer.bytes().enumerate().any(|(i, a)| {
-                if a == g && !used[i] {
-                    used[i] = true;
-                    return true;
-                }
-                false
-            });
-            if is_misplaced != (*e == Correctness::Misplaced) {
+            if Correctness::is_misplaced(g, answer, &mut used) != (*e == Correctness::Misplaced) {
                 return false;
             }
         }
@@ -110,13 +113,7 @@ impl Correctness {
                 // Already marked as green
                 continue;
             }
-            if answer.bytes().enumerate().any(|(i, a)| {
-                if a == g && !used[i] {
-                    used[i] = true;
-                    return true;
-                }
-                false
-            }) {
+            if Correctness::is_misplaced(g, answer, &mut used) {
                 c[i] = Correctness::Misplaced;
             }
         }
@@ -144,7 +141,7 @@ impl Guess<'_> {
     pub fn matches(&self, word: &str) -> bool {
         // if guess G gives mask C against answer A, then
         // guess A should also give mask C against answer G.
-        Correctness::compute(word, &self.word) == self.mask
+        Correctness::check(word, &self.word, &self.mask)
     }
 }
 


### PR DESCRIPTION
This brings a 2.4x speedup on my machine

This function is called inside the inner most loop, so small improvements have the greatest effect here I guess.

The `Correctness::check()` mirrors `Correctness::compute()` providing the same result as comparing a pattern against a computed result, but this allows short circuiting the check at the first mismatch.

I didn't make this a separate implementation/algorithm, as the change is mainly in the lib side.