### PR TITLE
Optimize and simplify Correctness::compute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,24 +68,22 @@ impl Correctness {
         assert_eq!(answer.len(), 5);
         assert_eq!(guess.len(), 5);
         let mut c = [Correctness::Wrong; 5];
-        let mut used = [false; 5];
-        // Mark things green
-        for (i, (a, g)) in answer.bytes().zip(guess.bytes()).enumerate() {
-            if a == g {
+        let answer_bytes = answer.as_bytes();
+        let guess_bytes = guess.as_bytes();
+
+        for (i, &a) in answer_bytes.iter().enumerate() {
+            if a == guess_bytes[i] {
+                // Mark things green
                 c[i] = Correctness::Correct;
-                used[i] = true;
+            } else if let Some(j) = guess_bytes.iter().enumerate().position(|(j, &g)| {
+                // The position in guess can only be marked as Misplaced, if it isn't Correct and wasn't already marked before.
+                a == g && answer_bytes[j] != a && c[j] == Correctness::Wrong
+            }) {
+                // Mark things yellow
+                c[j] = Correctness::Misplaced;
             }
         }
 
-        for (i, g) in guess.bytes().enumerate() {
-            if c[i] == Correctness::Correct {
-                // Already marked as green
-                continue;
-            }
-            if Correctness::is_misplaced(g, answer, &mut used) {
-                c[i] = Correctness::Misplaced;
-            }
-        }
         c
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,3 +76,18 @@ where
     }
     println!("average score: {:.2}", score as f64 / games as f64);
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn first_10_games_with_cutoff() {
+        let w = roget::Wordle::new();
+        let results: Vec<_> = crate::GAMES
+            .split_whitespace()
+            .take(10)
+            .filter_map(|answer| w.play(answer, roget::algorithms::Cutoff::new()))
+            .collect();
+
+        assert_eq!(results, [4, 4, 4, 4, 4, 5, 4, 5, 4, 2]);
+    }
+}


### PR DESCRIPTION
by reducing it's implementation into one loop and removing the used array.
The unit tests helped a lot thanks 😄 
It's mostly a simplification, it improves the performance only a bit.
```
> hyperfine.exe -n old '.\roget-base.exe --implementation cutoff' -n new '.\target\release\roget.exe --implementation cutoff'
Benchmark 1: old
  Time (mean ± σ):      8.366 s ±  0.010 s    [User: 0.000 s, System: 0.006 s]
  Range (min … max):    8.346 s …  8.381 s    10 runs

Benchmark 2: new
  Time (mean ± σ):      7.958 s ±  0.005 s    [User: 0.000 s, System: 0.003 s]
  Range (min … max):    7.949 s …  7.964 s    10 runs

Summary
  'new' ran
    1.05 ± 0.00 times faster than 'old'
```