### PR TITLE
Housekeeping/Clippy Lints

### DIFF
--- a/src/algorithms/cache.rs
+++ b/src/algorithms/cache.rs
@@ -21,7 +21,12 @@ impl CacheValue {
 }
 
 const NUM_WORDS: usize = DICTIONARY.len();
+// Since we use these as initializers only, I think they are fine.
+// If we do not have these and we attempt to have set the default normally, the compiler
+// complains that Cell is non-copy.
+#[allow(clippy::declare_interior_mutable_const)]
 const CELL: Cell<Option<CacheValue>> = Cell::new(None);
+#[allow(clippy::declare_interior_mutable_const)]
 const ROW: [Cell<Option<CacheValue>>; NUM_WORDS] = [CELL; NUM_WORDS];
 
 struct Cache([[Cell<Option<CacheValue>>; NUM_WORDS]; NUM_WORDS]);
@@ -155,7 +160,7 @@ impl Cached {
         }));
 
         COMPUTES.with(|c| {
-            c.get_or_init(|| Box::default());
+            c.get_or_init(Box::default);
         });
 
         Self {

--- a/src/algorithms/cache.rs
+++ b/src/algorithms/cache.rs
@@ -6,7 +6,6 @@ use std::cell::Cell;
 use std::num::NonZeroU8;
 
 static INITIAL: OnceCell<Vec<(&'static str, f64, usize)>> = OnceCell::new();
-static PATTERNS: OnceCell<Vec<[Correctness; 5]>> = OnceCell::new();
 
 #[derive(Copy, Clone)]
 struct CacheValue(NonZeroU8);
@@ -44,7 +43,6 @@ thread_local! {
 
 pub struct Cached {
     remaining: Cow<'static, Vec<(&'static str, f64, usize)>>,
-    patterns: Cow<'static, Vec<[Correctness; 5]>>,
     entropy: Vec<f64>,
 }
 
@@ -162,7 +160,6 @@ impl Cached {
 
         Self {
             remaining,
-            patterns: Cow::Borrowed(PATTERNS.get_or_init(|| Correctness::patterns().collect())),
             entropy: Vec::new(),
         }
     }
@@ -225,12 +222,9 @@ impl Guesser for Cached {
             });
         }
         if history.is_empty() {
-            self.patterns = Cow::Borrowed(PATTERNS.get().unwrap());
             // NOTE: I did a manual run with this commented out and it indeed produced "tares" as
             // the first guess. It slows down the run by a lot though.
             return "tares".to_string();
-        } else {
-            assert!(!self.patterns.is_empty());
         }
 
         let remaining_p: f64 = self.remaining.iter().map(|&(_, p, _)| p).sum();

--- a/src/algorithms/cutoff.rs
+++ b/src/algorithms/cutoff.rs
@@ -3,11 +3,9 @@ use once_cell::sync::OnceCell;
 use std::borrow::Cow;
 
 static INITIAL: OnceCell<Vec<(&'static str, usize)>> = OnceCell::new();
-static PATTERNS: OnceCell<Vec<[Correctness; 5]>> = OnceCell::new();
 
 pub struct Cutoff {
     remaining: Cow<'static, Vec<(&'static str, usize)>>,
-    patterns: Cow<'static, Vec<[Correctness; 5]>>,
 }
 
 impl Default for Cutoff {
@@ -20,7 +18,6 @@ impl Cutoff {
     pub fn new() -> Self {
         Self {
             remaining: Cow::Borrowed(INITIAL.get_or_init(|| DICTIONARY.to_vec())),
-            patterns: Cow::Borrowed(PATTERNS.get_or_init(|| Correctness::patterns().collect())),
         }
     }
 }
@@ -49,10 +46,7 @@ impl Guesser for Cutoff {
             }
         }
         if history.is_empty() {
-            self.patterns = Cow::Borrowed(PATTERNS.get().unwrap());
             return "tares".to_string();
-        } else {
-            assert!(!self.patterns.is_empty());
         }
 
         let remaining_count: usize = self.remaining.iter().map(|&(_, c)| c).sum();

--- a/src/algorithms/escore.rs
+++ b/src/algorithms/escore.rs
@@ -3,11 +3,9 @@ use once_cell::sync::OnceCell;
 use std::borrow::Cow;
 
 static INITIAL: OnceCell<Vec<(&'static str, f64)>> = OnceCell::new();
-static PATTERNS: OnceCell<Vec<[Correctness; 5]>> = OnceCell::new();
 
 pub struct Escore {
     remaining: Cow<'static, Vec<(&'static str, f64)>>,
-    patterns: Cow<'static, Vec<[Correctness; 5]>>,
     entropy: Vec<f64>,
 }
 
@@ -116,7 +114,6 @@ impl Escore {
                     .map(|(word, count)| (word, sigmoid(count as f64 / sum as f64)))
                     .collect()
             })),
-            patterns: Cow::Borrowed(PATTERNS.get_or_init(|| Correctness::patterns().collect())),
             entropy: Vec::new(),
         }
     }
@@ -148,12 +145,9 @@ impl Guesser for Escore {
             }
         }
         if history.is_empty() {
-            self.patterns = Cow::Borrowed(PATTERNS.get().unwrap());
             // NOTE: I did a manual run with this commented out and it indeed produced "tares" as
             // the first guess. It slows down the run by a lot though.
             return "tares".to_string();
-        } else {
-            assert!(!self.patterns.is_empty());
         }
 
         let remaining_p: f64 = self.remaining.iter().map(|&(_, p)| p).sum();

--- a/src/algorithms/sigmoid.rs
+++ b/src/algorithms/sigmoid.rs
@@ -3,11 +3,9 @@ use once_cell::sync::OnceCell;
 use std::borrow::Cow;
 
 static INITIAL: OnceCell<Vec<(&'static str, f64)>> = OnceCell::new();
-static PATTERNS: OnceCell<Vec<[Correctness; 5]>> = OnceCell::new();
 
 pub struct Sigmoid {
     remaining: Cow<'static, Vec<(&'static str, f64)>>,
-    patterns: Cow<'static, Vec<[Correctness; 5]>>,
 }
 
 impl Default for Sigmoid {
@@ -74,7 +72,6 @@ impl Sigmoid {
                     .map(|(word, count)| (word, sigmoid(count as f64 / sum as f64)))
                     .collect()
             })),
-            patterns: Cow::Borrowed(PATTERNS.get_or_init(|| Correctness::patterns().collect())),
         }
     }
 }
@@ -103,10 +100,7 @@ impl Guesser for Sigmoid {
             }
         }
         if history.is_empty() {
-            self.patterns = Cow::Borrowed(PATTERNS.get().unwrap());
             return "tares".to_string();
-        } else {
-            assert!(!self.patterns.is_empty());
         }
 
         let remaining_p: f64 = self.remaining.iter().map(|&(_, p)| p).sum();


### PR DESCRIPTION
Three minor changes:
* Removed patterns from cuttoff & later strategies as mentioned in previous PR.
  * This was actually removed from enumerate when it was made, but I forgot to remove it from the derived strategies
* Removed redundant lambda 
* Disabled clippy lints for `declare_interior_mutable_const` for the initiator consts
  * I think this lint is a false positive, since these are just used for initialization and are "copied" in default. There may be a better way to implement default for Cache, but this is what I landed on.