### PR TITLE
Fix issue with cutoffs for small number of remaining items.

### DIFF
--- a/src/solver.rs
+++ b/src/solver.rs
@@ -335,7 +335,7 @@ impl Guesser for Solver {
 
         let mut best: Option<Candidate> = None;
         let mut i = 0;
-        let stop = (self.remaining.len() / 3).max(20);
+        let stop = (self.remaining.len() / 3).max(20).min(self.remaining.len());
         let consider = if self.options.hard_mode {
             &*self.remaining
         } else if self.options.sigmoid {


### PR DESCRIPTION
There is unexpected behavior when the list of remaining words is less than 20 in easy mode.

The issue is that when the number of remaining words is less than 20, we still set the `stop` to 20, but `i` will never reach that. This is fine in hard mode because the iterator will run out after all remaining words are processed, but in easy mode we will process the full dictionary. This does causes an increase in runtime for marginal benefit in score, but the point of cutoff mode is to sacrifice score for better performance.

I discovered this while playing around with parallelism, but was getting slightly different results with the same configuration.

| Version | Runtime | Score |
| --- | --- | --- |
| main Branch | ~36s | 3.6215 |
| This PR | ~30s | 3.6223 |