### PR TITLE
Basic attempt at making guessing parallel.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +60,57 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdbfe11fe19ff083c48923cf179540e8cd0535903dc35e178a1fdeeb59aef51f"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "hashbrown"
@@ -103,6 +160,25 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -162,12 +238,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "roget"
 version = "0.1.0"
 dependencies = [
  "clap",
  "once_cell",
+ "rayon",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ debug = true
 [dependencies]
 clap = { version = "3", features = ["derive"] }
 once_cell = "1"
+rayon = "1.5.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ struct Args {
     #[clap(short, long, arg_enum, default_value = "expected-score")]
     rank_by: Rank,
 
-    /// By default, correcness computation are cached. This flag disables that.
+    /// By default, correctness computation are cached. This flag disables that.
     #[clap(long)]
     no_cache: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{ArgEnum, Parser};
+use rayon::ThreadPoolBuilder;
 use roget::{Guesser, Solver};
 
 const GAMES: &str = include_str!("../answers.txt");
@@ -37,6 +38,15 @@ struct Args {
     /// If not passed, all Wordle games are run.
     #[clap(short, long)]
     games: Option<usize>,
+
+    /// Sets the number of threads to use in thread pool.
+    ///
+    /// By default, only one thread is used.
+    ///
+    /// Specifying this with no value or a value of 0 uses the
+    /// default number of threads for rayon.
+    #[clap(short, long, default_value = "1", default_missing_value = "0")]
+    threads: usize,
 }
 
 #[derive(ArgEnum, Debug, Clone, Copy)]
@@ -80,6 +90,11 @@ fn main() {
         Rank::InfoPlusProbability => roget::Rank::InfoPlusProbability,
         Rank::ExpectedInformation => roget::Rank::ExpectedInformation,
     };
+
+    ThreadPoolBuilder::new()
+        .num_threads(args.threads)
+        .build_global()
+        .unwrap();
     play(move || solver.build(), args.games);
 }
 

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -15,7 +15,7 @@ static INITIAL_COUNTS: OnceCell<InitialWords> = OnceCell::new();
 /// The initial set of words after applying sigmoid smoothing.
 static INITIAL_SIGMOID: OnceCell<InitialWords> = OnceCell::new();
 
-/// A per-thread cache of cached `Correctness` for each word pair.
+/// A cache of `Correctness` for each word pair.
 type Cache = [Mutex<[PackedCorrectness; DICTIONARY.len()]>; DICTIONARY.len()];
 static COMPUTES: OnceCell<Box<Cache>> = OnceCell::new();
 

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -1,5 +1,6 @@
 use crate::{Correctness, Guess, Guesser, PackedCorrectness, DICTIONARY, MAX_MASK_ENUM};
 use once_cell::sync::OnceCell;
+use rayon::current_num_threads;
 use rayon::prelude::*;
 use std::borrow::Cow;
 use std::cmp::Ordering;
@@ -391,9 +392,8 @@ impl Guesser for Solver {
                 },
             )
         };
-
-        // only running thread pool on larger lists give ~10% speed up
-        let best = if stop > 25 {
+        // only running thread pool on larger lists give minor speed up, ~5% in default config with threads
+        let best = if current_num_threads() > 1 && stop > 25 {
             consider
                 .par_iter()
                 .take(stop)

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -306,12 +306,12 @@ impl Guesser for Solver {
                     &COMPUTES.get().unwrap()[word_idx];
                 for (candidate, count, candidate_idx) in &*self.remaining {
                     let idx = get_packed(row, word, candidate, *candidate_idx);
-                    totals[usize::from(u8::from(idx))] += count;
+                    totals[usize::from(idx)] += count;
                 }
             } else {
                 for (candidate, count, _) in &*self.remaining {
                     let idx = PackedCorrectness::packed(Correctness::compute(candidate, word));
-                    totals[usize::from(u8::from(idx))] += count;
+                    totals[usize::from(idx)] += count;
                 }
             }
 

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -56,7 +56,7 @@ impl Default for Solver {
 //   E[guesses] = ln(entropy * 3.869 + 3.679)
 //
 // and an average score of 3.7176 (worse than the first estimate). Further iterations did not
-// change the parameters much, so I stuck with that last estimat.
+// change the parameters much, so I stuck with that last estimate.
 //
 // Below are also the formulas and average scores when using different regressions. Interestingly,
 // the regression that does the best also tends to overestimate the number of guesses remaining,
@@ -187,7 +187,7 @@ impl Options {
 
             for (orig_idx, (word, count)) in DICTIONARY.iter().copied().enumerate() {
                 let mask = PackedCorrectness::packed(Correctness::compute(word, FIRST_WORD));
-                vec[mask as usize].push((word, map(count, sum), orig_idx))
+                vec[usize::from(mask)].push((word, map(count, sum), orig_idx))
             }
 
             let mut prev = 0usize;
@@ -288,8 +288,7 @@ impl Guesser for Solver {
 
         if let Some(last) = history.last() {
             if history.len() == 1 && last.word == FIRST_WORD {
-                let (start, end) =
-                    self.ranges[PackedCorrectness::packed(last.mask) as usize].clone();
+                let (start, end) = self.ranges[usize::from(PackedCorrectness::packed(last.mask))];
                 let slice = &if self.options.sigmoid {
                     INITIAL_SIGMOID.get()
                 } else {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -137,7 +137,7 @@ pub struct Options {
     /// If true, candidates will be ranked based on expected score.
     pub rank_by: Rank,
 
-    /// If true, correcness computation will be cached.
+    /// If true, correctness computation will be cached.
     pub cache: bool,
 
     /// If true, only the most likely 1/3 of candidates are considered at each step.

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -16,11 +16,6 @@ static INITIAL_COUNTS: OnceCell<InitialWords> = OnceCell::new();
 static INITIAL_SIGMOID: OnceCell<InitialWords> = OnceCell::new();
 
 /// A per-thread cache of cached `Correctness` for each word pair.
-///
-/// We make this thread-local so that access to it is as cheap as we can get it.
-///
-/// We store a `Box` because the array is quite large, and we're unlikely to have the stack space
-/// needed to store the whole thing on a given thread's stack.
 type Cache = [Mutex<[PackedCorrectness; DICTIONARY.len()]>; DICTIONARY.len()];
 static COMPUTES: OnceCell<Box<Cache>> = OnceCell::new();
 


### PR DESCRIPTION
This PR makes a basic attempt at parallelizing guessing. You probably have made your own versions but I figured a publicly visible PR would serve as a good base line.

The cache was changed so that every line is behind a Mutex instead of using Cells or Atomics for each entry. This was chosen as the overhead for supporting parallelism is only incurred once per row and all iterations are row based.

For the actual parallelism, a simple `par_iter` idiom from rayon is used. To do this I needed to make the main for loop into a a more iterative style. The main portion of the loop was pulled into a lambda, the iteration limit is handled by some pre-calculation and `take`, and lastly the best candidate tracking is handled by `max_by` , a match to replicate the implicit preference for more likely guesses, and an annoying unwrap (which can be replaced by `total_cmp` when stabilized).

There is heuristic to determine when to use the rayon thread pool, if there are not many items to be iterated over or if the pool is configured for one thread, we just do the processing on the main thread.

Overall this gives a decent performance improvement when running with `--no-cutoff` and `--easy` enabled, but a very poor speed up on the quicker default settings.

Results on my 2700x (8 Core, 16 Threads):
```
cargo build --release; hyperfine -w 3 -L threads 1,4,8,16 -n 'full easy {threads}' 'cargo run --release -- --no-cutoff --easy -t {threads}'
    Finished release [optimized + debuginfo] target(s) in 4.93s
Benchmark 1: full easy 1
  Time (mean ± σ):     61.099 s ±  1.211 s    [User: 0.005 s, System: 0.015 s]
  Range (min … max):   60.385 s … 64.484 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to
 use the '--warmup' or '--prepare' options.

Benchmark 2: full easy 4
  Time (mean ± σ):     18.230 s ±  0.288 s    [User: 0.008 s, System: 0.011 s]
  Range (min … max):   17.835 s … 18.743 s    10 runs

Benchmark 3: full easy 8
  Time (mean ± σ):     12.353 s ±  0.173 s    [User: 0.008 s, System: 0.005 s]
  Range (min … max):   12.187 s … 12.703 s    10 runs                         

Benchmark 4: full easy 16
  Time (mean ± σ):     11.120 s ±  0.054 s    [User: 0.002 s, System: 0.012 s]
  Range (min … max):   11.072 s … 11.255 s    10 runs

Summary
  'full easy 16' ran
    1.11 ± 0.02 times faster than 'full easy 8'
    1.64 ± 0.03 times faster than 'full easy 4'
    5.49 ± 0.11 times faster than 'full easy 1'
```

```
cargo build --release; hyperfine -w 3 -L threads 1,4,8,16 -n 'default {threads}' 'cargo run --release -- -t {threads}'  
    Finished release [optimized + debuginfo] target(s) in 4.43s
Benchmark 1: default 1
  Time (mean ± σ):     871.9 ms ±   4.1 ms    [User: 5.1 ms, System: 8.9 ms]
  Range (min … max):   866.2 ms … 878.1 ms    10 runs

Benchmark 2: default 4
  Time (mean ± σ):     597.1 ms ±   4.4 ms    [User: 0.8 ms, System: 8.7 ms]
  Range (min … max):   590.3 ms … 605.5 ms    10 runs

Benchmark 3: default 8
  Time (mean ± σ):     579.2 ms ±   3.1 ms    [User: 2.5 ms, System: 10.4 ms]
  Range (min … max):   574.2 ms … 583.8 ms    10 runs

Benchmark 4: default 16
  Time (mean ± σ):     617.3 ms ±   4.3 ms    [User: 1.7 ms, System: 8.9 ms]
  Range (min … max):   612.3 ms … 625.7 ms    10 runs

Summary
  'default 8' ran
    1.03 ± 0.01 times faster than 'default 4'
    1.07 ± 0.01 times faster than 'default 16'
    1.51 ± 0.01 times faster than 'default 1'
```